### PR TITLE
use join() instead of fold() in _loadFile

### DIFF
--- a/lib/src/pool.dart
+++ b/lib/src/pool.dart
@@ -100,8 +100,6 @@ class AppstreamPool {
       stream = gzip.decoder.bind(stream);
     }
 
-    return await utf8.decoder
-        .bind(stream)
-        .fold('', (prev, element) => prev + element);
+    return await utf8.decoder.bind(stream).join();
   }
 }


### PR DESCRIPTION
Slightly improves performance since `join()` uses a `StringBuffer`.