### PR TITLE
fix: support appstream releases with missing version

### DIFF
--- a/lib/src/collection.dart
+++ b/lib/src/collection.dart
@@ -844,7 +844,7 @@ class AppstreamCollection {
     }
 
     return AppstreamCollection(
-        version: _parseYamlVersion(version),
+        version: _parseYamlVersion(version)!,
         origin: origin,
         architecture: architecture,
         priority: priority,
@@ -855,11 +855,11 @@ class AppstreamCollection {
   String toString() => "$runtimeType(version: $version, origin: '$origin')";
 }
 
-String _parseYamlVersion(dynamic value) {
+String? _parseYamlVersion(dynamic value) {
   if (value is double) {
     return value.toString();
   } else {
-    return value as String;
+    return value as String?;
   }
 }
 

--- a/test/appstream_test.dart
+++ b/test/appstream_test.dart
@@ -899,6 +899,7 @@ Releases:
   date: 2013-10-20
 - version: 1.0
   unix-timestamp: 1345939200
+- unix-timestamp: 1234567890
 """);
     expect(collection.components, hasLength(1));
     var component = collection.components[0];
@@ -920,7 +921,8 @@ Releases:
               version: '1.1',
               type: AppstreamReleaseType.development,
               date: DateTime(2013, 10, 20)),
-          AppstreamRelease(version: '1.0', date: DateTime.utc(2012, 8, 26))
+          AppstreamRelease(version: '1.0', date: DateTime.utc(2012, 8, 26)),
+          AppstreamRelease(date: DateTime.utc(2009, 2, 13, 23, 31, 30)),
         ]));
   });
 


### PR DESCRIPTION
This PR fixes a bug discovered in https://github.com/ubuntu/app-center/issues/1901:

`_parseYamlVersion` currently assumes the argument is never `null`, even though `version` in `AppstreamRelease` is nullable and the [appstream specification](https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Releases.html#spec-releases) doesn't require a `version` property to be present.

On plucky there's at least one appstream component where a release doesn't have a version:
```
$ appstreamcli dump com.simutrans.Simutrans | xmllint --xpath '/component/releases/release' -
<release type="stable" date="2025-01-31T00:00:00Z"/>
```

UDENG-6502